### PR TITLE
Added babel-jest for node v4 and v5

### DIFF
--- a/generators/app/templates/.babelrc
+++ b/generators/app/templates/.babelrc
@@ -3,6 +3,9 @@
     ["transform-flow-strip-types"]
   ],<% } %>
   "env": {
+    "test": {
+      "presets": ["es2015"]
+    },
     "cjs": {
       "presets": [
         ["es2015", {"loose": true}]

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -58,9 +58,13 @@
   "author": "<%= author %> (<%= email %>)",
   "license": "<%= license %>",
   "repository": "<%= github %>/<%= name %>",
+  "jest": {
+    "scriptPreprocessor": "<rootDir>/node_modules/babel-jest"
+  },
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-core": "^6.17.0",
+    "babel-jest": "^18.0.0",
     "babel-plugin-add-module-exports": "^0.2.1",
     <% if(flow) { %>"babel-plugin-transform-flow-strip-types": "^6.18.0",<% } %>
     "babel-preset-es2015": "^6.16.0",


### PR DESCRIPTION
- Adds babel-jest as a dev dependency
- Adds babel-jest transpiler options
- Adds required babel presets for the test environment on `.babelrc`